### PR TITLE
move 4 p2 unit to p2 perf

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -220,12 +220,12 @@ device_groups:
     pixel2-32:
     pixel2-33:
     pixel2-34:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-35:
     pixel2-36:
     pixel2-37:
     pixel2-38:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-39:
     pixel2-40:
     pixel2-41:


### PR DESCRIPTION
We currently run more perf jobs.

current:
```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 22
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 20
pixel2-unit-2: 27
s7-perf: 2
s7-unit: 2
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 23
p2: 48
s7: 4
total: 75
```

with this PR:
```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 22
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 23
s7-perf: 2
s7-unit: 2
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 23
p2: 48
s7: 4
total: 75
```