### PR TITLE
replace p2-51

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -196,7 +196,7 @@ device_groups:
     # pixel2-08:
     # pixel2-09:
     # pixel2-10:
-    # pixel2-11:
+    pixel2-11:
     pixel2-12:
     pixel2-13:
     pixel2-14:
@@ -219,9 +219,9 @@ device_groups:
     pixel2-31:
     pixel2-32:
     pixel2-33:
-    pixel2-34:
   pixel2-perf:
   pixel2-perf-2:
+    pixel2-34:
     pixel2-35:
     pixel2-36:
     pixel2-37:
@@ -238,7 +238,7 @@ device_groups:
     pixel2-48:
     pixel2-49:
     pixel2-50:
-    pixel2-51:
+    # pixel2-51: # removed from cluster due to flakiness (hangs, turns off)
     # pixel2-52: # removed from cluster due to battery bloat
     pixel2-53:
     pixel2-54:


### PR DESCRIPTION
p2-51 is having issues. Replace it with a previously deactivated device.

Output below shows no changes in counts.

before:
```
$ ./bin/device_group_report 
Using config file at '/Users/aerickson/git/mozilla-bitbar-devicepool/config/config.yml'.
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 22
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 23
s7-perf: 2
s7-unit: 2
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 23
p2: 48
s7: 4
total: 75
```

after:
```
$ ./bin/device_group_report 
Using config file at '/Users/aerickson/git/mozilla-bitbar-devicepool/config/config.yml'.
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 22
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 23
s7-perf: 2
s7-unit: 2
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 23
p2: 48
s7: 4
total: 75
```