### PR TITLE
reduce cluster size to match 2021 contract

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -139,7 +139,7 @@ device_groups:
     # motog5-04:
     # motog5-05:
     # motog5-06:
-    # motog5-07:  # replaces 5-31  # disabled due to 2021 contract
+    motog5-07:  # replaces 5-31
     # motog5-08:
     # motog5-09:
     # motog5-10:
@@ -166,7 +166,7 @@ device_groups:
     motog5-30:
     # motog5-31:  # bad device
     motog5-32:
-    motog5-33:
+    # motog5-33:  # disabled due to 2021 contract (and battery bloat)
     motog5-34:
     motog5-35:
     motog5-36:
@@ -196,31 +196,31 @@ device_groups:
     # pixel2-08:
     # pixel2-09:
     # pixel2-10:
-    # pixel2-11:  # 11-18 disabled due to 2021 contract size
-    # pixel2-12:
-    # pixel2-13:
-    # pixel2-14:
-    # pixel2-15:
-    # pixel2-16:
-    # pixel2-17:
-    # pixel2-18:
+    pixel2-11:
+    pixel2-12:
+    # pixel2-13:  # disabled due to 2021 contract (and battery bloat)
+    # pixel2-14:  # disabled due to 2021 contract (and battery bloat)
+    pixel2-15:
+    pixel2-16:
+    pixel2-17:
+    pixel2-18:
     pixel2-19:
     pixel2-20:
     pixel2-21:
     pixel2-22:
-    pixel2-23:
-    pixel2-24:
-    pixel2-25:
-    pixel2-26:
-    pixel2-27:
+    # pixel2-23:  # disabled due to 2021 contract (and battery bloat)
+    # pixel2-24:  # disabled due to 2021 contract (and battery bloat)
+    # pixel2-25:  # disabled due to 2021 contract (and battery bloat)
+    # pixel2-26:  # disabled due to 2021 contract (and battery bloat)
+    # pixel2-27:  # disabled due to 2021 contract (and battery bloat)
     pixel2-28:
     pixel2-29:
-    pixel2-30:
-    pixel2-31:
-    pixel2-32:
-    pixel2-33:
   pixel2-perf:
   pixel2-perf-2:
+    pixel2-30:
+    pixel2-31:
+    # pixel2-32:  # disabled due to 2021 contract (and battery bloat)
+    pixel2-33:
     pixel2-34:
     pixel2-35:
     pixel2-36:

--- a/config/config.yml
+++ b/config/config.yml
@@ -139,7 +139,7 @@ device_groups:
     # motog5-04:
     # motog5-05:
     # motog5-06:
-    motog5-07:  # replaces 5-31
+    # motog5-07:  # replaces 5-31  # disabled due to 2021 contract
     # motog5-08:
     # motog5-09:
     # motog5-10:
@@ -196,14 +196,14 @@ device_groups:
     # pixel2-08:
     # pixel2-09:
     # pixel2-10:
-    pixel2-11:
-    pixel2-12:
-    pixel2-13:
-    pixel2-14:
-    pixel2-15:
-    pixel2-16:
-    pixel2-17:
-    pixel2-18:
+    # pixel2-11:  # 11-18 disabled due to 2021 contract size
+    # pixel2-12:
+    # pixel2-13:
+    # pixel2-14:
+    # pixel2-15:
+    # pixel2-16:
+    # pixel2-17:
+    # pixel2-18:
     pixel2-19:
     pixel2-20:
     pixel2-21:

--- a/config/config.yml
+++ b/config/config.yml
@@ -215,12 +215,12 @@ device_groups:
     # pixel2-27:  # disabled due to 2021 contract (and battery bloat)
     pixel2-28:
     pixel2-29:
-  pixel2-perf:
-  pixel2-perf-2:
     pixel2-30:
     pixel2-31:
     # pixel2-32:  # disabled due to 2021 contract (and battery bloat)
     pixel2-33:
+  pixel2-perf:
+  pixel2-perf-2:
     pixel2-34:
     pixel2-35:
     pixel2-36:


### PR DESCRIPTION
2021 contract is for 22 g5s, 40 p2s, 4 s7gs.

old:

```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 22
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 23
s7-perf: 2
s7-unit: 2
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 23
p2: 48
s7: 4
total: 75
```

new: 

```
/// g-w workers ///
motog5-batt-2: 0
motog5-perf-2: 21
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 15
s7-perf: 2
s7-unit: 2
/// test workers ///
motog5-test: 0
test-1: 1
test-2: 1
test-3: 0
/// device summary ///
g5: 22
p2: 40
s7: 4
total: 66
```