### PR TITLE
add more s7 perf capacity

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -250,8 +250,8 @@ device_groups:
   pixel2-batt:
   pixel2-batt-2:
   s7-unit:
+  s7-perf:
     s7-01:
     s7-02:
-  s7-perf:
     s7-03:
     s7-04:


### PR DESCRIPTION
It seems like we're not going to run any unit tests, so move the 2 unit devices to the perf queue.