### PR TITLE
add a51 devices to test-1

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -106,7 +106,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20201110T135924
+      DOCKER_IMAGE_VERSION: 20211130T120953
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb
@@ -115,7 +115,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-3
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-3
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20201110T135924
+      DOCKER_IMAGE_VERSION: 20211130T120953
   # mozilla-docker-image-test:
   #   device_group_name: motog5-test
   #   framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -97,7 +97,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20211122T154221
+      DOCKER_IMAGE_VERSION: 20211130T120953
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -177,8 +177,10 @@ device_groups:
   motog5-unit-2:
   motog5-test:
   test-1:
-    motog5-40:
+    a51-01:
+    a51-02:
   test-2:
+    motog5-40:
     # pixel2-60 has android 9.0 on it
     pixel2-60:
   test-3:

--- a/config/config.yml
+++ b/config/config.yml
@@ -181,9 +181,9 @@ device_groups:
     a51-02:
   test-2:
     motog5-40:
+  test-3:
     # pixel2-60 has android 9.0 on it
     pixel2-60:
-  test-3:
   motog5-batt:
   motog5-batt-2:
   pixel2-unit:

--- a/config/config.yml
+++ b/config/config.yml
@@ -97,7 +97,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20201110T135924
+      DOCKER_IMAGE_VERSION: 20211122T154221
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -50,6 +50,8 @@ class DeviceGroupReport:
             # print(the_item)
             if the_item:
                 for device in the_item:
+                    if "a51" in device:
+                        self.device_dict["a51"] = self.device_dict.get("a51", 0) + 1
                     if "s7" in device:
                         self.device_dict["s7"] = self.device_dict.get("s7", 0) + 1
                     if "pixel2" in device:


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1739469.

- use new image in test queues
- update device_group_report to support a51
- put a51 devices in test-1, p2 and g5 test devices in test-2 and test-3