### PR TITLE
use 20211130T120953 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20201110T135924
+      DOCKER_IMAGE_VERSION: 20211130T120953
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
test pushes:
- p2: https://treeherder.mozilla.org/jobs?repo=try&revision=fe1fef35f5e5afa9bfdecf2f6b1514eee2116ffb
- g5: https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&revision=e8a5d0bfb72ae98aed2b9e0838dd359482846aa4

a51 verified to work in https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/2