### PR TITLE
device group report: detect a51 queues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,18 +6,18 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-    - id: black
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
     - id: flake8
 -   repo: local

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -40,7 +40,11 @@ class DeviceGroupReport:
             if "-builder" not in group:
                 if "test" in group:
                     self.test_result_dict[group] = get_len(the_item)
-                elif group.endswith("2") or group.startswith("s7"):
+                elif (
+                    group.endswith("2")
+                    or group.startswith("s7")
+                    or group.startswith("a51")
+                ):
                     self.gw_result_dict[group] = get_len(the_item)
                 else:
                     self.tcw_result_dict[group] = get_len(the_item)


### PR DESCRIPTION
Also updates pre-commit hooks.

new output (was previously missing a51 queues):

```
Using config file at '/Users/aerickson/git/mozilla-bitbar-devicepool/config/config.yml'.
/// g-w workers ///
a51-perf: 7
a51-unit: 0
motog5-batt-2: 0
motog5-perf-2: 21
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 15
s7-perf: 4
s7-unit: 0
/// test workers ///
motog5-test: 0
test-1: 0
test-2: 1
test-3: 1
/// device summary ///
g5: 22
p2: 40
a51: 7
s7: 4
total: 73
```