### PR TITLE
use 20220331T141348 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20211130T120953
+      DOCKER_IMAGE_VERSION: 20220331T141348
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
sets the new 'upgrade mercurial' image (built in https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/3) to default.

see https://bugzilla.mozilla.org/show_bug.cgi?id=1760840

tests: 
- view-fenix test (passing now, the test failing in m-c causing us to upgrade): https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&revision=59ec5e25b59b928bbf284a43dc52db0a8aee34ff&selectedTaskRun=bskqmFEmSxWrIFyhBwMhow.0
- general tests: https://treeherder.mozilla.org/jobs?repo=try&revision=0d506d4f3877c0f467dd5891388b6a095ca6b2f0