### PR TITLE
api and config comparator

### DIFF
--- a/bin/compare_to_api
+++ b/bin/compare_to_api
@@ -43,7 +43,14 @@ def get_device_names():
     return devices
 
 
-api_devices = get_device_names()
+try:
+    api_devices = get_device_names()
+except AttributeError as e:
+    print("Please ensure the bitbar env vars have been set!")
+    print("  - TESTDROID_URL and TESTDROID_APIKEY")
+    print("full exception follows")
+    print("")
+    raise e
 api_devices_set = set(api_devices)
 print("api devices: ")
 print(f"  {api_devices}")

--- a/bin/compare_to_api
+++ b/bin/compare_to_api
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# compares bitbar api devices to devices in our config
+
+import os
+import sys
+
+try:
+    from testdroid import Testdroid
+
+    from mozilla_bitbar_devicepool.bitbar.devices import get_devices
+
+    from mozilla_bitbar_devicepool.device_group_report import DeviceGroupReport
+except ImportError:
+    print("ERROR: Please install dependencies (`pip install -r requirements.txt`)!")
+    sys.exit(1)
+
+
+TESTDROID_URL = os.environ.get("TESTDROID_URL")
+TESTDROID_APIKEY = os.environ.get("TESTDROID_APIKEY")
+if TESTDROID_URL and TESTDROID_APIKEY:
+    TESTDROID = Testdroid(apikey=TESTDROID_APIKEY, url=TESTDROID_URL)
+else:
+    TESTDROID = None
+
+# print(TESTDROID)
+
+
+# get devices from the api
+#
+# returns array of strings
+def get_device_names():
+    display_names = {}
+    for device in get_devices():
+        dn = device["displayName"]
+        # skip docker builder, not a real device
+        if dn == "Docker Builder":
+            continue
+        display_names[dn] = True
+
+    devices = sorted(display_names.keys())
+
+    return devices
+
+
+api_devices = get_device_names()
+api_devices_set = set(api_devices)
+print("api devices: ")
+print(f"  {api_devices}")
+print(f"  count: {len(api_devices)}")
+
+print("")
+
+# config_path=args.config_file
+dgri = DeviceGroupReport(quiet=True)
+config_devices = dgri.get_config_devices()
+config_devices_set = set(config_devices)
+print("config devices: ")
+print(f"  {config_devices}")
+print(f"  count: {len(config_devices)}")
+
+print("")
+print("api - config: ")
+print(f"  {api_devices_set.difference(config_devices_set)}")
+print("config - api: ")
+print(f"  {config_devices_set.difference(api_devices_set)}")

--- a/bin/compare_to_api
+++ b/bin/compare_to_api
@@ -55,7 +55,7 @@ print("")
 dgri = DeviceGroupReport(quiet=True)
 config_devices = dgri.get_config_devices()
 config_devices_set = set(config_devices)
-print("config devices: ")
+print(f"config ({dgri.config_path}) devices: ")
 print(f"  {config_devices}")
 print(f"  count: {len(config_devices)}")
 

--- a/mozilla_bitbar_devicepool/device_group_report.py
+++ b/mozilla_bitbar_devicepool/device_group_report.py
@@ -14,7 +14,7 @@ def get_len(an_object):
 
 
 class DeviceGroupReport:
-    def __init__(self, config_path=None):
+    def __init__(self, config_path=None, quiet=False):
         self.gw_result_dict = {}
         self.tcw_result_dict = {}
         self.test_result_dict = {}
@@ -23,9 +23,30 @@ class DeviceGroupReport:
             pathname = os.path.dirname(sys.argv[0])
             root_dir = os.path.abspath(os.path.join(pathname, ".."))
             self.config_path = os.path.join(root_dir, "config", "config.yml")
-            print("Using config file at '%s'." % self.config_path)
+            if not quiet:
+                print("Using config file at '%s'." % self.config_path)
         else:
             self.config_path = config_path
+
+    def get_config_devices(self):
+        # TODO: store this data in the instance and only read once
+
+        with open(self.config_path, "r") as stream:
+            try:
+                conf_yaml = yaml.safe_load(stream)
+            except yaml.YAMLError as exc:
+                print(exc)
+
+        device_names = {}
+
+        for group in conf_yaml["device_groups"]:
+            the_item = conf_yaml["device_groups"][group]
+            if the_item:
+                for device in the_item:
+                    if device == "Docker Builder":
+                        continue
+                    device_names[device] = True
+        return sorted(device_names.keys())
 
     def get_report_dict(self):
         with open(self.config_path, "r") as stream:


### PR DESCRIPTION
Tool to compare the devices reported by the Bitbar API with the devices in our local config.

output example:
```
api devices: 
  ['a51-01', 'a51-02', 'a51-03', 'a51-04', 'a51-05', 'a51-06', 'a51-07', 'a51-08', 'a51-09', 'a51-10', 'a51-11', 'a51-12', 'a51-13', 'a51-14', 'a51-15', 'a51-16', 'a51-17', 'a51-18', 'a51-19', 'a51-20', 'a51-21', 'a51-22', 'a51-23', 'a51-24', 'a51-25', 'a51-26', 'a51-27', 'motog5-26', 'motog5-27', 'motog5-28', 'motog5-29', 'motog5-30', 'motog5-32', 'motog5-34', 'motog5-35', 'motog5-36', 'motog5-37', 'motog5-38', 'pixel2-12', 'pixel2-15', 'pixel2-16', 'pixel2-17', 'pixel2-18', 'pixel2-19', 'pixel2-20', 'pixel2-21', 'pixel2-22', 'pixel2-26', 'pixel2-27', 'pixel2-28', 'pixel2-29', 'pixel2-30', 'pixel2-31', 'pixel2-33', 'pixel2-34', 'pixel2-35', 'pixel2-36', 'pixel2-37', 'pixel2-38', 'pixel2-39', 'pixel2-40', 'pixel2-41', 'pixel2-42', 'pixel2-43', 'pixel2-44', 'pixel2-45', 'pixel2-46', 'pixel2-47', 'pixel2-48', 'pixel2-49', 'pixel2-50', 'pixel2-54', 'pixel2-55', 'pixel2-56', 'pixel2-57', 'pixel2-58', 'pixel2-59']
  count: 77

config (/Users/aerickson/git/mozilla-bitbar-devicepool/config/config.yml) devices: 
  ['a51-01', 'a51-02', 'a51-03', 'a51-04', 'a51-05', 'a51-06', 'a51-07', 'a51-08', 'a51-09', 'a51-10', 'a51-11', 'a51-12', 'a51-13', 'a51-14', 'a51-15', 'a51-16', 'a51-17', 'a51-18', 'a51-19', 'a51-20', 'a51-21', 'a51-22', 'a51-23', 'a51-24', 'a51-25', 'a51-26', 'a51-27', 'motog5-26', 'motog5-27', 'motog5-28', 'motog5-29', 'motog5-30', 'motog5-32', 'motog5-34', 'motog5-35', 'motog5-36', 'motog5-37', 'motog5-38', 'pixel2-12', 'pixel2-15', 'pixel2-16', 'pixel2-17', 'pixel2-18', 'pixel2-19', 'pixel2-20', 'pixel2-21', 'pixel2-22', 'pixel2-26', 'pixel2-27', 'pixel2-28', 'pixel2-29', 'pixel2-30', 'pixel2-31', 'pixel2-33', 'pixel2-34', 'pixel2-35', 'pixel2-36', 'pixel2-37', 'pixel2-38', 'pixel2-39', 'pixel2-40', 'pixel2-41', 'pixel2-42', 'pixel2-43', 'pixel2-44', 'pixel2-45', 'pixel2-46', 'pixel2-47', 'pixel2-48', 'pixel2-49', 'pixel2-50', 'pixel2-54', 'pixel2-55', 'pixel2-56', 'pixel2-57', 'pixel2-58', 'pixel2-59']
  count: 77

api - config: 
  set()
config - api: 
  set()
```