### PR TITLE
disable 6 g5 devices

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -175,13 +175,13 @@ device_groups:
     # motog5-23:  # disabled for a51
     # motog5-24:  # disabled for a51
     # motog5-25:  # disabled for a51
-    motog5-26:
-    motog5-27:
-    motog5-28:
-    motog5-29:
-    motog5-30:
+    # motog5-26:  # 7/13/22: disabled for a51
+    # motog5-27:  # 7/13/22: disabled for a51
+    # motog5-28:  # 7/13/22: disabled for a51
+    # motog5-29:  # 7/13/22: disabled for a51
+    # motog5-30:  # 7/13/22: disabled for a51
     # motog5-31:  # bad device
-    motog5-32:
+    # motog5-32:  # 7/13/22: disabled for a51
     # motog5-33:  # disabled due to 2021 contract (and battery bloat)
     motog5-34:
     motog5-35:


### PR DESCRIPTION
Disable 6 G5 devices. Part of the A51 migration.

before
```
/// g-w workers ///
a51-perf: 27
a51-unit: 0
motog5-batt-2: 0
motog5-perf-2: 11
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 15
s7-perf: 0
s7-unit: 0
/// test workers ///
motog5-test: 0
test-1: 0
test-2: 0
test-3: 0
/// device summary ///
g5: 11
a51: 27
p2: 39
total: 77
```

after
```
/// g-w workers ///
a51-perf: 27
a51-unit: 0
motog5-batt-2: 0
motog5-perf-2: 5
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 24
pixel2-unit-2: 15
s7-perf: 0
s7-unit: 0
/// test workers ///
motog5-test: 0
test-1: 0
test-2: 0
test-3: 0
/// device summary ///
g5: 5
a51: 27
p2: 39
total: 71
```