### PR TITLE
replace failed devices

### DIFF
--- a/bin/compare_to_api
+++ b/bin/compare_to_api
@@ -68,6 +68,6 @@ print(f"  count: {len(config_devices)}")
 
 print("")
 print("api - config: ")
-print(f"  {api_devices_set.difference(config_devices_set)}")
+print(f"  {sorted(api_devices_set.difference(config_devices_set))}")
 print("config - api: ")
-print(f"  {config_devices_set.difference(api_devices_set)}")
+print(f"  {sorted(config_devices_set.difference(api_devices_set))}")

--- a/config/config.yml
+++ b/config/config.yml
@@ -248,7 +248,7 @@ device_groups:
     pixel2-15:
     # pixel2-16:  # 7/14/22: failed device
     pixel2-17:
-    pixel2-18:
+    # pixel2-18:  # 7/17/22: failed device
     # pixel2-19:  # 7/14/22: failed device
     pixel2-20:
     pixel2-21:
@@ -261,7 +261,7 @@ device_groups:
     pixel2-29:
     pixel2-30:
     pixel2-31:
-    # pixel2-32:  # disabled due to 2021 contract (and battery bloat)
+    pixel2-32:
     pixel2-33:
   pixel2-perf:
   pixel2-perf-2:
@@ -280,7 +280,7 @@ device_groups:
     pixel2-45:
     pixel2-46:
     pixel2-47:
-    pixel2-48:
+    # pixel2-48:  # 7/17/22: failed device
     pixel2-49:
     pixel2-50:
     # pixel2-51: # removed from cluster due to flakiness (hangs, turns off)
@@ -292,6 +292,7 @@ device_groups:
     pixel2-57:
     pixel2-58:
     pixel2-59:
+    pixel2-60:
   pixel2-batt:
   pixel2-batt-2:
   s7-unit:


### PR DESCRIPTION
Bitbar has notified us that these devices have failed.

Also: tweak output of 'compare to api' script.