### PR TITLE
use new 2204 docker image in test pools

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -187,12 +187,13 @@ device_groups:
     # motog5-35:  # disabled 8/9/22
     motog5-36:
     motog5-37:
+    motog5-38:
     # motog5-39:  # bad device
   motog5-unit:
   motog5-unit-2:
   motog5-test:
   test-1:
-    motog5-38:
+    pixel2-02:
   test-2:
     # motog5-40:  # disabled due to a51 device increases (3/29/22)
   test-3:
@@ -232,7 +233,6 @@ device_groups:
   pixel2-unit:
   pixel2-unit-2:
     # pixel2-01:
-    pixel2-02:
     # pixel2-03:
     # pixel2-04:
     # pixel2-05:

--- a/config/config.yml
+++ b/config/config.yml
@@ -122,7 +122,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-2
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-2
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20211130T120953
+      DOCKER_IMAGE_VERSION: 20220902T165809
   mozilla-gw-test-3:
     device_group_name: test-3
     framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -195,6 +195,7 @@ device_groups:
   test-1:
     pixel2-02:
   test-2:
+    a51-21:
     # motog5-40:  # disabled due to a51 device increases (3/29/22)
   test-3:
     # pixel2-60 has android 9.0 on it
@@ -221,7 +222,6 @@ device_groups:
       a51-18:
       a51-19:
       a51-20:
-      a51-21:
       a51-22:
       a51-23:
       a51-24:

--- a/config/config.yml
+++ b/config/config.yml
@@ -113,7 +113,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20211130T120953
+      DOCKER_IMAGE_VERSION: 20220804T124127
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -113,7 +113,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20220804T124127
+      DOCKER_IMAGE_VERSION: 20220902T133609
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -257,14 +257,14 @@ device_groups:
     # pixel2-24:  # disabled due to 2021 contract (and battery bloat)
     # pixel2-25:  # disabled due to 2021 contract (and battery bloat)
     pixel2-26:
-  pixel2-perf:
-  pixel2-perf-2:
-    # pixel2-27:  # 7/14/22: failed device
     pixel2-28:
     pixel2-29:
     pixel2-30:
     pixel2-31:
     pixel2-32:
+  pixel2-perf:
+  pixel2-perf-2:
+    # pixel2-27:  # 7/14/22: failed device
     pixel2-33:
     pixel2-34:
     pixel2-35:

--- a/config/config.yml
+++ b/config/config.yml
@@ -257,14 +257,14 @@ device_groups:
     # pixel2-24:  # disabled due to 2021 contract (and battery bloat)
     # pixel2-25:  # disabled due to 2021 contract (and battery bloat)
     pixel2-26:
+  pixel2-perf:
+  pixel2-perf-2:
+    # pixel2-27:  # 7/14/22: failed device
     pixel2-28:
     pixel2-29:
     pixel2-30:
     pixel2-31:
     pixel2-32:
-  pixel2-perf:
-  pixel2-perf-2:
-    # pixel2-27:  # 7/14/22: failed device
     pixel2-33:
     pixel2-34:
     pixel2-35:

--- a/config/config.yml
+++ b/config/config.yml
@@ -113,7 +113,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20220902T133609
+      DOCKER_IMAGE_VERSION: 20220902T165809
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb


### PR DESCRIPTION
built in https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/4