### PR TITLE
use 20220902T165809 (Ubuntu 22.04 and Py3.9) as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20220331T141348
+      DOCKER_IMAGE_VERSION: 20220902T165809
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
Testing on this image (that upgrades to Ubuntu 22.04 and Py3.9) looks good. Make it the default.

Testing notes in https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/4 (https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/4#issuecomment-1235894379 onward).

PR using this image in test pools: https://github.com/mozilla-platform-ops/mozilla-bitbar-devicepool/pull/29.