### PR TITLE
use new image with p5 support as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20220902T165809
+      DOCKER_IMAGE_VERSION: 20221010T124603
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   mozilla-gw-unittest-p2:


### PR DESCRIPTION
built in https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/5

tested in https://github.com/mozilla-platform-ops/mozilla-bitbar-devicepool/pull/36