### PR TITLE
test-run-manager: add sentry exception monitoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run: pip3 install -r requirements-dev.txt
       - run: pip3 install -e .
       - run: pytest -v mozilla_bitbar_devicepool
+      - run: pytest --cov=mozilla_bitbar_devicepool
 
 workflows:
   main_test:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    *_test.py

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 *.egg-info
 .idea
 .vscode
+.coverage

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -9,6 +9,7 @@ import threading
 import time
 
 import requests
+import sentry_sdk
 from testdroid import RequestResponseError
 
 from mozilla_bitbar_devicepool import configuration, logger
@@ -30,6 +31,14 @@ CACHE = None
 CONFIG = None
 ARCHIVED_FILE_REGEX = r"FileEntity with id [\d]* does not exist"
 PROJECT_DOES_NOT_EXIST_REGEX = r"Project with id [\d]* does not exist"
+
+sentry_sdk.init(
+    dsn="https://6219c1b8ecb6484b82586c55ad99a87e@o1069899.ingest.sentry.io/4504301875691520",
+    # Set traces_sample_rate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production.
+    traces_sample_rate=1.0,
+)
 
 
 class TestRunManager(object):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pre-commit
 pylint
 pytest
 pytest-watch
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # roughly equivalent to `python setup.py develop`
 -e .
 
-PyYAML==5.3.1
+PyYAML==6.0
 requests==2.28.1
 testdroid==2.100.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 -e .
 
 PyYAML==5.3.1
-requests==2.24.0
+requests==2.28.1
 testdroid==2.100.0
 
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@
 PyYAML==5.3.1
 requests==2.24.0
 testdroid==2.100.0
+
+sentry-sdk


### PR DESCRIPTION
Adds sentry exception monitoring to test-run-manager.
- testing done: starts locally with no exceptions
- security reviews done: OK to include DSN in public code. An attacker could post false events. If it becomes a problem, specific IP ranges can be whitelisted.

Additionally:
- circleci: add coverage report
- requirements: update to latest

