### PR TITLE
logging.error() -> logging.warning()

### DIFF
--- a/mozilla_bitbar_devicepool/configuration.py
+++ b/mozilla_bitbar_devicepool/configuration.py
@@ -121,14 +121,14 @@ def configure(bitbar_configpath, filespath=None, update_bitbar=False):
     try:
         ensure_filenames_are_unique(CONFIG)
     except (ConfigurationFileException) as e:
-        logger.error(e.message)
+        logger.warning(e.message)
         sys.exit(1)
     expand_configuration()
     try:
         configuration_preflight()
     except ConfigurationFileException as e:
-        logger.error(e)
-        logger.error(
+        logger.warning(e)
+        logger.warning(
             "Configuration files seem to be missing! Please place and restart. Exiting..."
         )
         sys.exit(1)
@@ -408,19 +408,19 @@ def configure_projects(update_bitbar=False):
                     description=project_config["description"],
                 )
             else:
-                logger.error(
+                logger.warning(
                     'archivingStrategy: pc: "{}" bb: "{}"'.format(
                         project_config["archivingStrategy"],
                         bitbar_project["archivingStrategy"],
                     )
                 )
-                logger.error(
+                logger.warning(
                     'archivingItemCount: pc: "{}" bb: "{}"'.format(
                         project_config["archivingItemCount"],
                         bitbar_project["archivingItemCount"],
                     )
                 )
-                logger.error(
+                logger.warning(
                     'description: pc: "{}" bb: "{}"'.format(
                         project_config["description"], bitbar_project["description"]
                     )

--- a/mozilla_bitbar_devicepool/main.py
+++ b/mozilla_bitbar_devicepool/main.py
@@ -41,7 +41,7 @@ def empty_test_zip(args):
 
 def test_run_manager(args):
     if not TESTDROID:
-        logger.error(
+        logger.warning(
             "The environment variabels TESTDROID_URL, TESTDROID_APIKEY both need to be set."
         )
         sys.exit(1)
@@ -56,10 +56,10 @@ def test_run_manager(args):
             bitbar_configpath, filespath=args.files, update_bitbar=args.update_bitbar
         )
     except configuration.DuplicateProjectException as e:
-        logger.error(
+        logger.warning(
             "Duplicate project found! Please archive all but one and restart. Exiting..."
         )
-        logger.error(e)
+        logger.warning(e)
         sys.exit(1)
 
     manager = TestRunManager(wait=args.wait)
@@ -68,7 +68,7 @@ def test_run_manager(args):
 
 def run_test(args):
     if not TESTDROID:
-        logger.error(
+        logger.warning(
             "The environment variabels TESTDROID_URL, TESTDROID_APIKEY both need to be set."
         )
         sys.exit(1)

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -179,23 +179,23 @@ class TestRunManager(object):
                             logger.info("test run {} started".format(test_run["id"]))
                 except RequestResponseError as e:
                     if e.status_code == 404 and re.search(ARCHIVED_FILE_REGEX, str(e)):
-                        logger.error(
+                        logger.warning(
                             "Test files have been archived. Exiting so configuration is rerun..."
                         )
-                        logger.error("%s: %s" % (e.__class__.__name__, e))
+                        logger.warning("%s: %s" % (e.__class__.__name__, e))
                         self.state = "STOP"
                     elif e.status_code == 404 and re.search(
                         PROJECT_DOES_NOT_EXIST_REGEX, str(e)
                     ):
-                        logger.error(
+                        logger.warning(
                             "Project does not exist!. Exiting so configuration is rerun..."
                         )
-                        logger.error("%s: %s" % (e.__class__.__name__, e))
+                        logger.warning("%s: %s" % (e.__class__.__name__, e))
                         self.state = "STOP"
                     else:
-                        logger.error("%s: %s" % (e.__class__.__name__, e))
+                        logger.warning("%s: %s" % (e.__class__.__name__, e))
                 except Exception as e:
-                    logger.error(
+                    logger.warning(
                         "Failed to create test run for group %s (%s: %s)."
                         % (device_group_name, e.__class__.__name__, e),
                         exc_info=True,
@@ -230,8 +230,8 @@ class TestRunManager(object):
             # gather all runs per project
             result = get_active_test_runs()
         except RequestResponseError as e:
-            logger.error("process_active_runs: RequestResponseError received")
-            logger.error(e)
+            logger.warning("process_active_runs: RequestResponseError received")
+            logger.warning(e)
             return
 
         for item in result:


### PR DESCRIPTION
Sentry creates an event for all logging.error calls by default. 

This doesn't match up with how devicepool operates. Devicepool handles exceptions and logs a message... more like a note (or warning) before continuing.

Switch all error() calls to warning(). 

---

https://docs.sentry.io/platforms/python/guides/logging/