### PR TITLE
test_run_manager: use faulthandler

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -26,7 +26,7 @@ from mozilla_bitbar_devicepool.taskcluster import get_taskcluster_pending_tasks
 # WARNING: not used everywhere yet!!!
 #
 # don't fire calls at bitbar, just mention you would
-TESTING = True
+TESTING = False
 
 CACHE = None
 CONFIG = None

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -26,7 +26,7 @@ from mozilla_bitbar_devicepool.taskcluster import get_taskcluster_pending_tasks
 # WARNING: not used everywhere yet!!!
 #
 # don't fire calls at bitbar, just mention you would
-TESTING = False
+TESTING = True
 
 CACHE = None
 CONFIG = None
@@ -40,7 +40,8 @@ sentry_sdk.init(
     # We recommend adjusting this value in production.
     traces_sample_rate=1.0,
 )
-# will dump a stack trace for all threads to sys.stderr on SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL
+# will dump a stack trace for all threads to sys.stderr on SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL and exit
+#   - USAGE: `kill -s SIGABRT <PID OF TEST_RUN_MANAGER>`
 faulthandler.enable()
 
 

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -7,6 +7,7 @@ import re
 import signal
 import threading
 import time
+import faulthandler
 
 import requests
 import sentry_sdk
@@ -39,6 +40,8 @@ sentry_sdk.init(
     # We recommend adjusting this value in production.
     traces_sample_rate=1.0,
 )
+# will dump a stack trace for all threads to sys.stderr on SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL
+faulthandler.enable()
 
 
 class TestRunManager(object):


### PR DESCRIPTION
Faulthandler allows dumping stack traces of all threads on a signal. 

This will aid in finding the issue we're experiencing with devicepool where it stops updating what jobs are running in Bitbar (causing no further jobs to be enqueued).

Tested locally (produces stack trace to STDERR on signal).