### PR TITLE
remove most p2 devices from cluster

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -46,54 +46,54 @@ projects:
     additional_parameters:
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-p5
       TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-p5
-  mozilla-gw-perftest-g5:
-    device_group_name: motog5-perf-2
-    device_model: motog5
-    framework_name: mozilla-usb
-    description: Mozilla Performance tests for MotoG5 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
-  mozilla-gw-batttest-p2:
-    device_group_name: pixel2-batt-2
-    device_model: pixel2
-    framework_name: mozilla-tcp
-    description: Mozilla Battery tests for Pixel2 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
-  mozilla-gw-batttest-g5:
-    device_group_name: motog5-batt-2
-    device_model: motog5
-    framework_name: mozilla-tcp
-    description: Mozilla Battery tests for MotoG5 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
-  mozilla-gw-unittest-g5:
-    device_group_name: motog5-unit-2
-    device_model: motog5
-    framework_name: mozilla-usb
-    description: Mozilla Unit tests for MotoG5 (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
-  mozilla-gw-unittest-s7:
-    device_group_name: s7-unit
-    device_model: s7
-    framework_name: mozilla-usb
-    description: Mozilla Unit tests for S7Galaxy (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-s7
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-s7
-  mozilla-gw-perftest-s7:
-    device_group_name: s7-perf
-    device_model: s7
-    framework_name: mozilla-usb
-    description: Mozilla Performance tests for S7Galaxy (using generic-worker)
-    additional_parameters:
-      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-s7
-      TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-s7
+  # mozilla-gw-perftest-g5:
+  #   device_group_name: motog5-perf-2
+  #   device_model: motog5
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Performance tests for MotoG5 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-g5
+  # mozilla-gw-batttest-p2:
+  #   device_group_name: pixel2-batt-2
+  #   device_model: pixel2
+  #   framework_name: mozilla-tcp
+  #   description: Mozilla Battery tests for Pixel2 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-p2
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-p2
+  # mozilla-gw-batttest-g5:
+  #   device_group_name: motog5-batt-2
+  #   device_model: motog5
+  #   framework_name: mozilla-tcp
+  #   description: Mozilla Battery tests for MotoG5 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-batt-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-batt-g5
+  # mozilla-gw-unittest-g5:
+  #   device_group_name: motog5-unit-2
+  #   device_model: motog5
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Unit tests for MotoG5 (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-g5
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-g5
+  # mozilla-gw-unittest-s7:
+  #   device_group_name: s7-unit
+  #   device_model: s7
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Unit tests for S7Galaxy (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-unit-s7
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-unit-s7
+  # mozilla-gw-perftest-s7:
+  #   device_group_name: s7-perf
+  #   device_model: s7
+  #   framework_name: mozilla-usb
+  #   description: Mozilla Performance tests for S7Galaxy (using generic-worker)
+  #   additional_parameters:
+  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-bitbar-perf-s7
+  #     TC_WORKER_TYPE: gecko-t-bitbar-gw-perf-s7
   mozilla-gw-unittest-a51:
     device_group_name: a51-unit
     device_model: a51

--- a/config/config.yml
+++ b/config/config.yml
@@ -284,16 +284,16 @@ device_groups:
     # pixel2-14:  # 1/10/23: p2 drawdown
     # pixel2-15:  # 1/10/23: p2 drawdown
     # pixel2-16:  # 7/14/22: failed device
-    pixel2-17:
+    # pixel2-17:  # 2/15/23: RELOPS-410: remove most p2
     # pixel2-18:  # 7/17/22: failed device
     # pixel2-19:  # 7/14/22: failed device
-    pixel2-20:
-    pixel2-21:
-    pixel2-22:
+    # pixel2-20:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-21:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-22:  # 2/15/23: RELOPS-410: remove most p2
     # pixel2-23:  # disabled due to 2021 contract (and battery bloat)
     # pixel2-24:  # disabled due to 2021 contract (and battery bloat)
     # pixel2-25:  # disabled due to 2021 contract (and battery bloat)
-    pixel2-26:
+    # pixel2-26:  # 2/15/23: RELOPS-410: remove most p2
     pixel2-28:
     pixel2-29:
     pixel2-30:
@@ -316,19 +316,19 @@ device_groups:
     # pixel2-44:  # 11/30/22: deactivated for phase 2 of p5
     # pixel2-45:  # 11/30/22: deactivated for phase 2 of p5
     # pixel2-46:  # 11/30/22: deactivated for phase 2 of p5
-    pixel2-47:
+    # pixel2-47:  # 2/15/23: RELOPS-410: remove most p2
     # pixel2-48:  # 7/17/22: failed device
-    pixel2-49:
-    pixel2-50:
+    # pixel2-49:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-50:  # 2/15/23: RELOPS-410: remove most p2
     # pixel2-51: # removed from cluster due to flakiness (hangs, turns off)
     # pixel2-52: # removed from cluster due to battery bloat
     # pixel2-53: # removed due to having issues
-    pixel2-54:
-    pixel2-55:
-    pixel2-56:
-    pixel2-57:
-    pixel2-58:
-    pixel2-59:
+    # pixel2-54:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-55:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-56:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-57:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-58:  # 2/15/23: RELOPS-410: remove most p2
+    # pixel2-59:  # 2/15/23: RELOPS-410: remove most p2
     # pixel2-60:  # lots of failures and on android 9 (vs 8)
   pixel2-batt:
   pixel2-batt-2:


### PR DESCRIPTION
Remove most pixel 2 devices from the cluster. Keep 3 p2 for unit tests. See [RELOPS-410](https://mozilla-hub.atlassian.net/browse/RELOPS-410).

Once landed, have Bitbar pull the following devices:
`['pixel2-01', 'pixel2-02', 'pixel2-08', 'pixel2-11', 'pixel2-12', 'pixel2-13', 'pixel2-14', 'pixel2-15', 'pixel2-17', 'pixel2-21', 'pixel2-22', 'pixel2-26', 'pixel2-47', 'pixel2-49', 'pixel2-50', 'pixel2-54', 'pixel2-55', 'pixel2-57', 'pixel2-58', 'pixel2-59']`

Also:
- disable unused projects

before:
```
/// g-w workers ///
a51-perf: 27
a51-unit: 0
motog5-batt-2: 0
motog5-perf-2: 0
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 9
pixel2-unit-2: 8
pixel5-perf: 2
pixel5-unit: 17
s7-perf: 0
s7-unit: 0
/// test workers ///
motog5-test: 0
test-1: 0
test-2: 0
test-3: 0
/// device summary ///
a51: 27
p5: 19
p2: 17
total: 63
```

after:
```
/// g-w workers ///
a51-perf: 27
a51-unit: 0
motog5-batt-2: 0
motog5-perf-2: 0
motog5-unit-2: 0
pixel2-batt-2: 0
pixel2-perf-2: 0
pixel2-unit-2: 3
pixel5-perf: 2
pixel5-unit: 17
s7-perf: 0
s7-unit: 0
/// test workers ///
motog5-test: 0
test-1: 0
test-2: 0
test-3: 0
/// device summary ///
a51: 27
p5: 19
p2: 3
total: 49
```
