### PR TITLE
replace p2-28 with p2-11

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -288,7 +288,7 @@ device_groups:
     # pixel2-08:  # 1/10/23: p2 drawdown
     # pixel2-09:
     # pixel2-10:
-    # pixel2-11:  # 1/10/23: p2 drawdown
+    pixel2-11:  # 1/10/23: p2 drawdown, 3/15/23: re-enabled due to 28's failure
     # pixel2-12:  # 1/10/23: p2 drawdown
     # pixel2-13:  # 1/10/23: p2 drawdown
     # pixel2-14:  # 1/10/23: p2 drawdown
@@ -304,7 +304,7 @@ device_groups:
     # pixel2-24:  # disabled due to 2021 contract (and battery bloat)
     # pixel2-25:  # disabled due to 2021 contract (and battery bloat)
     # pixel2-26:  # 2/15/23: RELOPS-410: remove most p2
-    pixel2-28:
+    # pixel2-28:  # 3/15/23: hardware failure
     pixel2-29:
     pixel2-30:
   pixel2-perf:


### PR DESCRIPTION
Bitbar has notified us that p2-28 has hardware issues. Replacing it with p2-11.