### PR TITLE
add one a55

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -331,6 +331,7 @@ device_groups:
       a55-49:
       a55-50:
       a55-51:
+      a55-52:
   s24-unit:
   s24-perf:
       s24-01:


### PR DESCRIPTION
Bitbar has renamed the device. Ready to add.

See https://mozilla-hub.atlassian.net/browse/RELOPS-976 for more details.

cluster state after this lands:
```bash
device types
{'a51': 20, 'a55': 52, 'pixel5': 19, 'pixel6': 4, 's21': 1, 's24': 4}

total devices: 100
```