### PR TITLE
scheduler: reduce number of waiting jobs

### DIFF
--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -156,14 +156,10 @@ class TestRunManager(object):
                 # TODO: vary this based on how many devices out of total this queue has
                 #   - set a global limit and then give each queue a fraction of that
                 max_jobs_to_have_waiting = 5
-                #
-                # logger.info(f"pre-hack: jobs to start: {jobs_to_start}")
-                # aje hack to see if fewer waiting jobs helps
                 if stats["WAITING"] >= max_jobs_to_have_waiting or pending_tasks == 0:
                     jobs_to_start = 0
                 else:
                     jobs_to_start = max(1, max_jobs_to_have_waiting - stats["WAITING"])
-                # logger.info(f"post-hack: jobs to start: {jobs_to_start}")
 
                 if jobs_to_start < 0:
                     jobs_to_start = 0

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -144,6 +144,14 @@ class TestRunManager(object):
                     + 1
                     + int(math.log10(1 + pending_tasks)),
                 )
+                # logger.info(f"pre-hack: jobs to start: {jobs_to_start}")
+                # aje hack to see if fewer waiting jobs helps
+                if stats["WAITING"] >= 5 or pending_tasks == 0:
+                    jobs_to_start = 0
+                else:
+                    jobs_to_start = 1
+                # logger.info(f"post-hack: jobs to start: {jobs_to_start}")
+
                 if jobs_to_start < 0:
                     jobs_to_start = 0
 

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -135,6 +135,10 @@ class TestRunManager(object):
                     )
                     logger.warning(e)
                     pending_tasks = 0
+
+                # 'jobs to start' algorithm v1
+                #   - basically start up to the number of devices in a group
+                #
                 # warning: only take the log of positive non-zero numbers, or a
                 # "ValueError: math domain error" will be raised
                 jobs_to_start = min(
@@ -144,12 +148,21 @@ class TestRunManager(object):
                     + 1
                     + int(math.log10(1 + pending_tasks)),
                 )
+
+                # 'jobs to start' algorithm v2
+                #  - start up to max_jobs_to_have_waiting jobs
+                #    - avoids overloading Bitbar with too many waiting jobs
+                #
+                # TODO: vary this based on how many devices out of total this queue has
+                #   - set a global limit and then give each queue a fraction of that
+                max_jobs_to_have_waiting = 5
+                #
                 # logger.info(f"pre-hack: jobs to start: {jobs_to_start}")
                 # aje hack to see if fewer waiting jobs helps
-                if stats["WAITING"] >= 5 or pending_tasks == 0:
+                if stats["WAITING"] >= max_jobs_to_have_waiting or pending_tasks == 0:
                     jobs_to_start = 0
                 else:
-                    jobs_to_start = max(1, 5 - stats["WAITING"])
+                    jobs_to_start = max(1, max_jobs_to_have_waiting - stats["WAITING"])
                 # logger.info(f"post-hack: jobs to start: {jobs_to_start}")
 
                 if jobs_to_start < 0:

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -149,7 +149,7 @@ class TestRunManager(object):
                 if stats["WAITING"] >= 5 or pending_tasks == 0:
                     jobs_to_start = 0
                 else:
-                    jobs_to_start = 1
+                    jobs_to_start = max(1, 5 - stats["WAITING"])
                 # logger.info(f"post-hack: jobs to start: {jobs_to_start}")
 
                 if jobs_to_start < 0:

--- a/mozilla_bitbar_devicepool/test_run_manager.py
+++ b/mozilla_bitbar_devicepool/test_run_manager.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import math
 import re
 import signal
 import threading
@@ -141,13 +140,14 @@ class TestRunManager(object):
                 #
                 # warning: only take the log of positive non-zero numbers, or a
                 # "ValueError: math domain error" will be raised
-                jobs_to_start = min(
-                    pending_tasks,
-                    stats["IDLE"]
-                    - stats["WAITING"]
-                    + 1
-                    + int(math.log10(1 + pending_tasks)),
-                )
+                #
+                # jobs_to_start = min(
+                #     pending_tasks,
+                #     stats["IDLE"]
+                #     - stats["WAITING"]
+                #     + 1
+                #     + int(math.log10(1 + pending_tasks)),
+                # )
 
                 # 'jobs to start' algorithm v2
                 #  - start up to max_jobs_to_have_waiting jobs
@@ -155,6 +155,7 @@ class TestRunManager(object):
                 #
                 # TODO: vary this based on how many devices out of total this queue has
                 #   - set a global limit and then give each queue a fraction of that
+                #
                 max_jobs_to_have_waiting = 5
                 if stats["WAITING"] >= max_jobs_to_have_waiting or pending_tasks == 0:
                     jobs_to_start = 0


### PR DESCRIPTION
The Bitbar API server was getting stuck with the number of pending/waiting jobs we enqueue (could be up to the number of devices in a pool). Reduce it to max 5 per queue.
- this worked to get us unblocked last night
- Bitbar is continuing to investigate why this is happening. They've said that the DB was/is saturated.