### PR TITLE
add 10 a55, remove 2 bad a51

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -250,10 +250,10 @@ device_groups:
       # a51-10: 9/13/24: removed
       # a51-11: 7/12/24: disabled as bad
       a51-12:
-      a51-13:
+      # a51-13: 11/26/24: disabled as bad
       a51-14:
       # a51-15: 10/11/24: removed, won't power on
-      a51-16:
+      # a51-16: 11/26/24: disabled as bad
       # a51-17: 7/11/24: disabled as bad
       a51-18:
       a51-19:
@@ -347,6 +347,17 @@ device_groups:
       a55-65:
       a55-66:
       a55-67:
+      a55-68:
+      a55-69:
+      a55-70:
+      a55-71:
+      a55-72:
+      a55-73:
+      a55-74:
+      a55-75:
+      a55-76:
+      a55-77:
+      a55-78:
   s24-unit:
   s24-perf:
       s24-01:


### PR DESCRIPTION
Add 10 a55, remove 2 bad a51 devices. See https://mozilla-hub.atlassian.net/browse/RELOPS-976.

Once landed, our state will be:

```
pool summary
{ 'a51-perf': 16,
  'a55-perf': 78,
  'pixel5-perf': 2,
  'pixel5-unit': 17,
  'pixel6-perf': 4,
  's21-perf': 1,
  's24-perf': 4,
  'test-1': 1}

device types
{'a51': 17, 'a55': 78, 'pixel5': 19, 'pixel6': 4, 's21': 1, 's24': 4}

total devices: 123
```