### PR TITLE
use latest test image 030425

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -232,6 +232,8 @@ device_groups:
     # testing android 13
     # a51-02: # running android 13, 2/26/25: removed
     s21-01:
+    a55-77:
+    a55-78:
   test-2:
     # motog5-40:  # disabled due to a51 device increases (3/29/22)
     # testing new image 20240307T112108
@@ -357,8 +359,6 @@ device_groups:
     a55-74:
     a55-75:
     a55-76:
-    a55-77:
-    a55-78:
   s24-unit:
   s24-perf:
     s24-01:

--- a/config/config.yml
+++ b/config/config.yml
@@ -193,7 +193,7 @@ projects:
       TASKCLUSTER_CLIENT_ID: project/autophone/bitbar-x-test-1
       TC_WORKER_TYPE: gecko-t-bitbar-gw-test-1
       # replace with version to test
-      DOCKER_IMAGE_VERSION: 20250228T135704
+      DOCKER_IMAGE_VERSION: 20250304T123621
   mozilla-gw-test-2:
     device_group_name: test-2
     framework_name: mozilla-usb

--- a/config/config.yml
+++ b/config/config.yml
@@ -231,10 +231,10 @@ device_groups:
     #
     # testing android 13
     # a51-02: # running android 13, 2/26/25: removed
-    s21-01:
     a55-77:
     a55-78:
   test-2:
+    s21-01:
     # motog5-40:  # disabled due to a51 device increases (3/29/22)
     # testing new image 20240307T112108
   test-3:


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/RELOPS-1293.

Image built from https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/10.