### PR TITLE
set image 20250304T123621 as default

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -11,7 +11,7 @@ projects:
     taskcluster_provisioner_id: proj-autophone
     additional_parameters:
       bitbar_cloud_url: https://mozilla.testdroid.com
-      DOCKER_IMAGE_VERSION: 20231106T174322
+      DOCKER_IMAGE_VERSION: 20250304T123621
       TC_WORKER_CONF: gecko-t-ap
   # generic-worker
   # mozilla-gw-unittest-p2:


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/RELOPS-1293.

Image built in https://github.com/mozilla-platform-ops/mozilla-bitbar-docker/pull/10.

Tested in https://treeherder.mozilla.org/jobs?repo=try&revision=0ee98912d00e25cc4599fb4164f1cdbaae359fdc.