### PR TITLE
systemd unit file fixes and config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ hyperexecute*
 .coverage*
 
 *.log
+*.bak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+The core Python package lives in `mozilla_bitbar_devicepool/`, with vendor-specific logic in `bitbar/` and `lambdatest/`. Supporting CLI entry points are defined in `pyproject.toml` and mirrored as helper scripts in `bin/`. Shared utils and report generators sit under `util/` and `device_group_report*.py`, while environment and service configuration lives in `config/` and `service/`. Tests reside in `mozilla_bitbar_devicepool/test/`, alongside fixture data in `test_data/`.
+
+## Build, Test, and Development Commands
+Run `poetry install --with=dev` to sync dependencies, then `poetry shell` for an interactive environment. Use `pre-commit install` once per clone to enable formatting and lint hooks. Execute unit tests with `pytest` or the coverage variant `pytest --cov --cov-report=term`. CLI entry points run via `poetry run`, e.g., `poetry run mld` for LambdaTest device runs or `poetry run dgr` for Bitbar reports.
+
+## Coding Style & Naming Conventions
+Stick to Python 3.9+ with 4-space indentation and descriptive, snake_case names for modules, functions, and variables. Formatting and imports are enforced by `ruff-format` with a 120-character line limit; structural linting runs via `ruff check --select I --fix` and `pylint` in CI/pre-commit. Configuration files use YAML or TOML—mirror existing key naming and comment styles.
+
+## Testing Guidelines
+Place new tests in `mozilla_bitbar_devicepool/test/` following the `<module>_test.py` pattern and reuse helpers in `util_test.py`. Prefer `pytest` fixtures over ad-hoc setup; store serialized inputs in `test_data/`. Validate coverage locally with `pytest --cov --cov-report=html` and ensure critical branches that touch vendor APIs are exercised via mocks.
+
+## Commit & Pull Request Guidelines
+Commit messages are short (≤72 characters), lowercase, and often scoped (`lt status: refresh cache`). Group related edits per commit and reference Bugzilla or GitHub IDs when applicable. Pull requests should describe vendor impact, outline testing (`pytest`, manual device run), and include screenshots or log snippets when UI or report output changes. Link configuration updates to rollout plans so reviewers can validate credentials and scheduling.

--- a/bin/lt_config_mover.sh
+++ b/bin/lt_config_mover.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+poetry run ./bin/configuration_device_tool -c lambdatest.yml "$@"

--- a/bin/start_mbd_new_server.sh
+++ b/bin/start_mbd_new_server.sh
@@ -4,4 +4,4 @@ set -e
 set -x
 
 . ./bitbar_env-v3-server.sh
-mbd start-test-run-manager -b config/config-v3-server.yml --update-bitbar
+poetry run mbd start-test-run-manager -b config/config-v3-server.yml --update-bitbar

--- a/bin/v3_config_mover.sh
+++ b/bin/v3_config_mover.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+poetry run ./bin/configuration_device_tool -c config-v3-server.yml "$@"

--- a/config/config-v3-server.yml
+++ b/config/config-v3-server.yml
@@ -262,6 +262,15 @@ device_groups:
     a55-141:
     a55-142:
     a55-143:
+    a55-25:
+    a55-26:
+    a55-27:
+    a55-28:
+    a55-29:
+    a55-43:
+    a55-44:
+    a55-45:
+    a55-47:
   test-p5:
     # pixel5-07:
     pixel5-12:
@@ -277,19 +286,6 @@ device_groups:
     s24-06:
     s24-05:
   test-2:
-    a55-25:  # testing out new server Kesrick set up
-    a55-26:  # testing out new server Kesrick set up
-    a55-27:  # testing out new server Kesrick set up
-    a55-28:  # testing out new server Kesrick set up
-    a55-29:  # testing out new server Kesrick set up
-    a55-43:  # testing out new server Kesrick set up
-    a55-44:  # testing out new server Kesrick set up
-    a55-45:  # testing out new server Kesrick set up
-    a55-46:  # testing out new server Kesrick set up
-    a55-47:  # testing out new server Kesrick set up
   test-3:
-    # s21-01:
-    # s24-01:
-    # s24-02:
-    # s24-03:
-    # s24-04:
+  test-999:
+    a55-46:  # SLOW. DON'T USE.

--- a/config/config-v3-server.yml
+++ b/config/config-v3-server.yml
@@ -229,18 +229,8 @@ device_groups:
   # motog4-docker-builder-2:
   #   Docker Builder:
   test-1:
-    a55-25:
-    a55-26:
-    a55-27:
-    a55-28:
-    a55-29:
     a55-30:
     a55-31:
-    a55-43:
-    a55-44:
-    a55-45:
-    a55-46:
-    a55-47:
     a55-51:
     a55-52:
     a55-56:
@@ -287,6 +277,16 @@ device_groups:
     s24-06:
     s24-05:
   test-2:
+    a55-25:  # testing out new server Kesrick set up
+    a55-26:  # testing out new server Kesrick set up
+    a55-27:  # testing out new server Kesrick set up
+    a55-28:  # testing out new server Kesrick set up
+    a55-29:  # testing out new server Kesrick set up
+    a55-43:  # testing out new server Kesrick set up
+    a55-44:  # testing out new server Kesrick set up
+    a55-45:  # testing out new server Kesrick set up
+    a55-46:  # testing out new server Kesrick set up
+    a55-47:  # testing out new server Kesrick set up
   test-3:
     # s21-01:
     # s24-01:

--- a/config/config.yml
+++ b/config/config.yml
@@ -234,10 +234,10 @@ device_groups:
     # a55-77:  # 5/9/25: removed, contract downsizing
     # a55-78:  # 5/9/25: removed, contract downsizing
   test-2:
-    s21-01:
     # motog5-40:  # disabled due to a51 device increases (3/29/22)
     # testing new image 20240307T112108
   test-3:
+    s21-01:
     # pixel2-60 has android 9.0 on it
     #pixel2-60: ## pulled 4/26/22
   a51-unit:

--- a/config/lambdatest.yml
+++ b/config/lambdatest.yml
@@ -34,7 +34,7 @@ projects:
   test-1:
   #     SCRIPT_REPO_COMMIT: future_commit
       TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-lambda-test-1
-      TC_WORKER_TYPE: gecko-t-lambda-gw-test-1
+      TC_WORKER_TYPE: gecko-t-lambda-test-1
   #     # override SCRIPT_REPO_COMMIT with a test commit
 device_groups:
   a55-perf:

--- a/config/lambdatest.yml
+++ b/config/lambdatest.yml
@@ -92,9 +92,9 @@ device_groups:
     R5CXC1AHXYD:  # 10/20/25: tested by joel, power meter good
     R5CXC1ARZDN:  # 10/20/25: tested by joel, power meter good
     R5CXC1HZA6V:  # 10/20/25: tested by joel, power meter good
+    RZCY10LGB6W:  # 2/23/26: had bad rotation, rotation code landed on master
+    RZCY2011M7N:  # 2/23/26: had bad rotation, rotation code landed on master
   a55-alpha:
-    RZCY2011M7N:  # 11/6/25: bad rotation, testing in alpha
-    RZCY10LGB6W:  # 11/6/25: bad rotation, testing in alpha
   a55-android16:
     R5CXC1ASA0L:  # 12/1/25: lt is attempting to upgrade to android 16, had bad power meter
     RZCY203N75Z:  # 12/1/25: lt is attempting to upgrade to android 16, had bad power meter

--- a/config/lambdatest.yml
+++ b/config/lambdatest.yml
@@ -48,7 +48,6 @@ device_groups:
     R5CXC1AHV4M:  # 9/10/25: recabled and verified by jmaher
     R5CXC1ASA3P:  # 9/11/25: recabled and verified by jmaher
     R5CXC1AP2KT:  # 9/11/25: recabled and verified by jmaher
-    R5CXC1HZK0W:  # 9/11/25: recabled and verified by jmaher
     R5CXC1ASA2E:  # 9/11/25: recabled and verified by jmaher
     R5CXC1ARM0A:  # 9/11/25: recabled and verified by jmaher
     R5CXC1AMNFY:  # 9/15/25: recabled and verified by jmaher
@@ -95,6 +94,7 @@ device_groups:
     RZCY10LGB6W:  # 2/23/26: had bad rotation, rotation code landed on master
     RZCY2011M7N:  # 2/23/26: had bad rotation, rotation code landed on master
   a55-alpha:
+    R5CXC1HZK0W:  # now on android 15, move to alpha for testing
   a55-android16:
     R5CXC1ASA0L:  # 12/1/25: lt is attempting to upgrade to android 16, had bad power meter
     RZCY203N75Z:  # 12/1/25: lt is attempting to upgrade to android 16, had bad power meter

--- a/config/lambdatest.yml
+++ b/config/lambdatest.yml
@@ -31,10 +31,10 @@ projects:
   stab:
     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-lambda-stab
     TC_WORKER_TYPE: gecko-t-lambda-stab
-  # test-1:
+  test-1:
   #     SCRIPT_REPO_COMMIT: future_commit
-  #     TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-lambda-test-1
-  #     TC_WORKER_TYPE: gecko-t-lambda-gw-test-1
+      TASKCLUSTER_CLIENT_ID: project/autophone/gecko-t-lambda-test-1
+      TC_WORKER_TYPE: gecko-t-lambda-gw-test-1
   #     # override SCRIPT_REPO_COMMIT with a test commit
 device_groups:
   a55-perf:
@@ -106,7 +106,7 @@ device_groups:
     47241FDAQ0016Y:
     47241FDAQ002C0:
   test-1:
+    R5CXC1ALFED:  # 9/18/25: recabled and verified by jmaher, 3/26/26: was in stab, stealing
   stab:
     R5CXC1ARELR:  # 10/1/25: was reseated, power cycled, and verified by jmaher
     RZCY10Y548K:  # 10/1/25: was reseated, power cycled, and verified by jmaher
-    R5CXC1ALFED:  # 9/18/25: recabled and verified by jmaher

--- a/lt_config_mover.sh
+++ b/lt_config_mover.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-set -x
-
-./bin/configuration_device_tool -c lambdatest.yml "$@"

--- a/mozilla_bitbar_devicepool/configuration_device_mover.py
+++ b/mozilla_bitbar_devicepool/configuration_device_mover.py
@@ -162,7 +162,7 @@ class ConfigurationDeviceMover:
 
         # Initialize target group if it's None/empty
         if device_groups[target_group] is None:
-            device_groups[target_group] = {}
+            device_groups[target_group] = CommentedMap()
 
         # Track results
         results = {"moved": [], "not_found": [], "already_in_target": [], "errors": []}

--- a/service/bitbar.service
+++ b/service/bitbar.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Bitbar Testrun manager service
+# retry forever, no rate limiting
+StartLimitBurst=0
 
 [Service]
 Type=simple
@@ -7,6 +9,7 @@ ExecStart=/bin/bash /home/bitbar/mozilla-bitbar-devicepool/bin/start_android_har
 # disable execstop, let systemd track the pid and manage shutdown
 #ExecStop=/bin/bash /home/bitbar/mozilla-bitbar-devicepool/bin/stop_android_hardware_testing.sh
 Restart=always
+RestartSec=30s
 # address intermittent hangs by restarting hourly (mega-punt), haven't been able to find deadlocks/source.
 RuntimeMaxSec=1h
 WorkingDirectory=/home/bitbar/mozilla-bitbar-devicepool

--- a/service/lambdatest.service
+++ b/service/lambdatest.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Lambdatest Testrun manager service
+# retry forever, no rate limiting
+StartLimitBurst=0
 
 [Service]
 Type=simple
@@ -7,6 +9,7 @@ ExecStart=/bin/bash /home/bitbar/mozilla-bitbar-devicepool/bin/start_ltdp.sh
 # disable execstop, let systemd track the pid and manage shutdown
 #ExecStop=/bin/bash /home/bitbar/mozilla-bitbar-devicepool/bin/stop_ltdp.sh
 Restart=always
+RestartSec=30s
 # restart process 24 hours to avoid any funk building up
 #  - disabled to find long-term bugs
 #RuntimeMaxSec=24h


### PR DESCRIPTION
Includes:
- config changes
- SystemD unit hardening
  - if service failed quickly, SystemD would mark it as failed despite `Restart=always`. now will keep retrying regardless.
- configuration mover tool fix
- AGENTS.md: add it 